### PR TITLE
Making the placeholder text useful

### DIFF
--- a/PRTG/partials/config.html
+++ b/PRTG/partials/config.html
@@ -4,7 +4,7 @@
 
 <h5>PRTG API Configuration</h5>
 <p>We recommend that you create a special-privilege account for remote API use.</p>
-<p>You will need to manually configure PRTG to send a CORS compliant response header. Read more at <em>PLACEHOLDER</em>.</p>
+<p>You will need to manually configure PRTG to send a CORS compliant response header. Read more at <a href="https://github.com/neuralfraud/grafana-prtg/wiki/Installation#pre-requisite-preparation">here</a>.</p>
 <div class="tight-form">
   <ul class="tight-form-list">
     <li class="tight-form-item" style="width: 80px">

--- a/PRTG/partials/config.html
+++ b/PRTG/partials/config.html
@@ -4,7 +4,7 @@
 
 <h5>PRTG API Configuration</h5>
 <p>We recommend that you create a special-privilege account for remote API use.</p>
-<p>You will need to manually configure PRTG to send a CORS compliant response header. Read more at <a href="https://github.com/neuralfraud/grafana-prtg/wiki/Installation#pre-requisite-preparation">here</a>.</p>
+<p>You will need to manually configure PRTG to send a CORS compliant response header. Read more <a href="https://github.com/neuralfraud/grafana-prtg/wiki/Installation#pre-requisite-preparation">here</a>.</p>
 <div class="tight-form">
   <ul class="tight-form-list">
     <li class="tight-form-item" style="width: 80px">


### PR DESCRIPTION
Currently the config page doesn't link to the correct place in the github wiki to set up PRTG.

I've removed the placeholder text and added a simple link. Think it was just missed during the release